### PR TITLE
feat(reporter): Sort license finding paths with localeCompare

### DIFF
--- a/plugins/reporters/web-app-template/src/components/PackageFindingsTable.js
+++ b/plugins/reporters/web-app-template/src/components/PackageFindingsTable.js
@@ -204,7 +204,7 @@ const PackageFindingsTable = (props) => {
             dataIndex: 'path',
             defaultSortOrder: 'ascend',
             key: 'path',
-            sorter: (a, b) => a.path.length - b.path.length,
+            sorter: (a, b) => a.path.localeCompare(b.path),
             textWrap: 'word-break',
             title: 'Path'
         },


### PR DESCRIPTION
Use localeCompare to sort paths textually.

Currently paths are sorted by their length, which produces an output that is hard to use. It seems much more natural to sort paths textually.

Old behaviour:
![image](https://github.com/AJDurant/ort/assets/763880/e99d8197-bf4f-45ee-815d-4de13f956486)

New behaviour:
![image](https://github.com/AJDurant/ort/assets/763880/7b36ae1b-e3ce-4e4d-b572-6b0df564918b)
